### PR TITLE
Switch to composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
       interval: daily
       time: '08:00'  # yamllint disable-line rule:quoted-strings
       timezone: America/Toronto
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
-      time: '08:00'  # yamllint disable-line rule:quoted-strings
-      timezone: America/Toronto

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,8 +11,6 @@ jobs:
   lint:
     name: Lint code base
     uses: bewuethr/workflows/.github/workflows/linter.yml@main
-    with:
-      validate-dockerfile: true
 
   shellcheck:
     name: Run shellcheck

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,4 +20,4 @@ jobs:
         uses: actions/checkout@v3.0.2
 
       - name: Run shellcheck
-        uses: bewuethr/shellcheck-action@v2
+        uses: bewuethr/shellcheck-action@39-switch-to-composite-action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM koalaman/shellcheck-alpine:v0.8.0
-RUN apk add --no-cache file=5.40-r1
-COPY runshellcheck /runshellcheck
-ENTRYPOINT ["/runshellcheck"]

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,17 @@
 name: Run ShellCheck
+
 author: Benjamin Wuethrich
+
 description: Run ShellCheck on all shell files
-runs:
-  using: docker
-  image: Dockerfile
+
 branding:
   icon: terminal
   color: green
+
+runs:
+  using: composite
+  steps:
+    - name: Run ShellCheck
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH/runshellcheck"

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,20 @@ branding:
 runs:
   using: composite
   steps:
+    - name: Install ShellCheck
+      shell: bash
+      env:
+        # yamllint disable-line rule:line-length
+        SC_URL: https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz
+      run: |
+        echo "Installing ShellCheck..." >&2
+          mkdir --parents "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          curl --silent --location "$SC_URL" \
+              | tar --extract --xz --directory="$HOME/.local/bin" \
+                  --strip-components=1 shellcheck-v0.8.0/shellcheck
+          shellcheck --version >&2
+
     - name: Run ShellCheck
       shell: bash
       run: |

--- a/runshellcheck
+++ b/runshellcheck
@@ -1,12 +1,13 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 find . \
 	-type d -name '.git' -prune \
-	-o \
+	-or \
 	-type f \( \
 	-exec sh -c 'file --brief "$1" \
-		  | grep -qE "((POSIX|Korn|Bourne-Again) shell|/usr/bin/env k?sh) script"' _ {} \; \
-	-o \
-	-name '*.sh' -o -name '*.bash' -o -name '*.ksh' \
+		  | grep --quiet --extended-regexp \
+			"((POSIX|Korn|Bourne-Again) shell|/usr/bin/env k?sh) script"' _ {} \; \
+	-or \
+	-name '*.sh' -or -name '*.bash' -or -name '*.ksh' \
 	\) \
 	-exec shellcheck --color=always {} +


### PR DESCRIPTION
- Switch action metadata to composite action
- Switch script to Bash
- Drop Dockerfile from dependabot checks
- Remove hadolint from linter workflow call
- Use new action
- Install ShellCheck v0.8.0 in action
