### PR TITLE
Bump runner to 24.04 and use local version of action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
 
   shellcheck:
     name: Run shellcheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4.2.2
 
-      - name: Run shellcheck
-        uses: bewuethr/shellcheck-action@v2
+      - name: Run action on itself
+        uses: ./.


### PR DESCRIPTION
This bumps the runner image for the ShellCheck job to Ubuntu 24.04, and runs the local version of the action instead of latest major version.